### PR TITLE
Fix imports and implement pure-python HTML parsing

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import os
+import sys
+
+# Ensure project root is on sys.path so 'src' can be imported
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)


### PR DESCRIPTION
## Summary
- add empty `src/__init__.py` so imports work
- provide local path setup for tests via `conftest.py`
- restrict pytest collection to repository tests
- rewrite `ContentProcessor` parsing helpers without external libs
- save markdown output in `WebContent`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fd5ef56a48330995525587966804d